### PR TITLE
chore(avatar): 🤖  adds avatar component

### DIFF
--- a/src/avatar/Avatar.spec.jsx
+++ b/src/avatar/Avatar.spec.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, cleanup } from 'react-testing-library';
+
+import { Avatar, AvatarHeading, AvatarImage } from './index';
+
+afterEach(cleanup);
+
+test('should render Avatar', () => {
+  const { getByTestId } = render(<Avatar data-testid="avatar" />);
+  expect(getByTestId('avatar')).toBeTruthy();
+});
+
+test('should render AvatarHeading', () => {
+  const { getByText } = render(<AvatarHeading>A header</AvatarHeading>);
+  expect(getByText('A header')).toBeTruthy();
+});
+
+test('should render AvatarImage', () => {
+  const { container } = render(
+    <AvatarImage
+      data-testid="image"
+      src="https://avatars3.githubusercontent.com/u/14904083?s=460&v=4"
+    />
+  );
+  expect(container.getElementsByTagName('img')).toHaveLength(1);
+});

--- a/src/avatar/index.jsx
+++ b/src/avatar/index.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import styled from 'styled-components';
+
+const Image = styled.img`
+  padding-right: 30px;
+  height: 80px;
+  width: 80px;
+`;
+
+export const Avatar = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  align-items: center;
+`;
+
+export const AvatarImage = ({ src }) => {
+  return <Image src={src} />;
+};
+
+export const AvatarHeading = styled.div`
+  flex: 1;
+`;

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
+export { Avatar, AvatarHeading, AvatarImage } from './avatar';
 export { Button } from './button';
 export { Card, CardBody } from './card';

--- a/src/preview.jsx
+++ b/src/preview.jsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import ReactDOM from 'react-dom';
 import styled from 'styled-components';
 
-import { Button, Card, CardBody } from './index';
+import { Button, Card, CardBody, Avatar, AvatarHeading, AvatarImage } from './index';
 
 const Container = styled.div`
   display: grid;
@@ -17,6 +17,26 @@ const StyledButton = styled(Button)`
 
 const Preview = () => (
   <Fragment>
+    <h2>Avatars</h2>
+    <Container>
+      <Avatar>
+        <AvatarImage src="https://avatars2.githubusercontent.com/u/8963736?s=460&v=4" />
+        <AvatarHeading>Alex Fenton</AvatarHeading>
+      </Avatar>
+      <Avatar>
+        <AvatarImage src="https://avatars3.githubusercontent.com/u/14904083?s=460&v=4" />
+        <AvatarHeading>Stefan McCready</AvatarHeading>
+      </Avatar>
+    </Container>
+    <h2>Avatars - No Label</h2>
+    <Container>
+      <Avatar>
+        <AvatarImage src="https://avatars2.githubusercontent.com/u/8963736?s=460&v=4" />
+      </Avatar>
+      <Avatar>
+        <AvatarImage src="https://avatars3.githubusercontent.com/u/14904083?s=460&v=4" />
+      </Avatar>
+    </Container>
     <h2>Button</h2>
     <StyledButton>Click Me!</StyledButton>
     <h2>Cards</h2>


### PR DESCRIPTION
Raised a pull request to check whether we want simple use of props. In this example using `src` as a means to pass a URL whilst making sure we have constant styles for the avatar. Saves the extra bit of nesting as well.

![screen shot 2019-02-26 at 20 04 03](https://user-images.githubusercontent.com/14904083/53442649-b8201780-3a01-11e9-9818-42b76de7f543.png)
